### PR TITLE
Use numbered arguments

### DIFF
--- a/public/application/single_pages/members/profile.php
+++ b/public/application/single_pages/members/profile.php
@@ -131,7 +131,7 @@ $userDisplayName = h(trim($profileData['first_name'] . " " . $profileData['last_
                             $communityPoints = Entry::getTotal($profile);
                             /** @noinspection PhpUnhandledExceptionInspection */
                             echo t(
-                                '%s has posted %s, been awarded %s and has accumulated %s since joining the community on %s.',
+                                '%1$s has posted %2$s, been awarded %3$s and has accumulated %4$s since joining the community on %5$s.',
                                 h($profile->getUserName()),
                                 sprintf("<b>%s</b>", t2("%s message", "%s messages", number_format($totalMessages))),
                                 sprintf("<a href=\"%s\"><strong>%s</strong></a>", (string)Url::to("/account/karma", $profile->getUserID()), t2("%s achievement", "%s achievements", number_format($totalAchievements))),

--- a/public/packages/concrete_cms_community/single_pages/account/karma.php
+++ b/public/packages/concrete_cms_community/single_pages/account/karma.php
@@ -121,7 +121,7 @@ $config = $app->make(Repository::class);
                                                         }
 
                                                         /** @noinspection HtmlUnknownTarget */
-                                                        echo t("Awarded to %s on %s",
+                                                        echo t("Awarded to %1$s on %2$s",
                                                             sprintf(
                                                                 "<a href=\"%s\">%s</a>",
                                                                 (string)Url::to("/members/profile", $entry->getUserPointEntryUserID()),

--- a/public/packages/concrete_cms_community/src/API/V1/Discourse.php
+++ b/public/packages/concrete_cms_community/src/API/V1/Discourse.php
@@ -186,7 +186,7 @@ class Discourse
                                                         } else if (isset($data[$eventType]["user_id"])) {
                                                             $userId = $data[$eventType]["user_id"];
 
-                                                            $this->logger->info(t("Event %s raised for discourse user with ID #%s.", $eventName, $userId));
+                                                            $this->logger->info(t("Event %1$s raised for discourse user with ID #%2$s.", $eventName, $userId));
 
                                                             /*
                                                              * Resolve mail address through discourse API

--- a/public/packages/concrete_cms_community/src/API/V1/ShowcaseItems.php
+++ b/public/packages/concrete_cms_community/src/API/V1/ShowcaseItems.php
@@ -98,7 +98,7 @@ class ShowcaseItems
 
         if ($file instanceof UploadedFile) {
             if ($file->getSize() > $maxFileSize) {
-                throw new Exception(t("The file size is to big."));
+                throw new Exception(t("The file size is too big."));
             } else {
                 $pathParts = pathinfo($file->getClientOriginalName());
                 $fileExtension = $pathParts['extension'];


### PR DESCRIPTION
Using numbered arguments will allow translators to switch the arguments order to allow more correct translations.